### PR TITLE
added composition by general operator

### DIFF
--- a/src/ProxStuff/calculus/precomposeNonlinear.jl
+++ b/src/ProxStuff/calculus/precomposeNonlinear.jl
@@ -1,0 +1,24 @@
+import ProximalOperators: gradient! # this can be removed when moved to Prox
+
+export PrecomposeNonlinear
+
+struct PrecomposeNonlinear{P <: ProximableFunction, T <: AbstractOperator} <: ProximableFunction
+	g::P
+    G::T
+end
+
+PrecomposeNonlinear(g::P, G::T) where {P, T} = PrecomposeNonlinear{P, T}(g, G)
+
+is_smooth(f::PrecomposeNonlinear) = is_smooth(f.g)
+
+function (f::PrecomposeNonlinear)(x)
+    return f.g(f.G*x)
+end
+
+function gradient!(y, f::PrecomposeNonlinear, x)
+    # not the most efficient thing
+    z, v = gradient(f.g, f.G*x)
+    J = Jacobian(f.G, x)
+    y = Ac_mul_B!(y, J, z)
+    return v
+end

--- a/src/RegLS.jl
+++ b/src/RegLS.jl
@@ -18,6 +18,7 @@ import ProximalOperators: RealOrComplex,
 
 include("ProxStuff/functions/sqrHingeLoss.jl") #to MOVE to ProximalOperators
 include("ProxStuff/functions/crossEntropy.jl") #to MOVE to ProximalOperators
+include("ProxStuff/calculus/precomposeNonlinear.jl") #to MOVE to ProximalOperators
 
 include("utilities/deep.jl")
 include("syntax/syntax.jl")

--- a/test/test_proxstuff.jl
+++ b/test/test_proxstuff.jl
@@ -47,3 +47,21 @@ end
 
 @test f(x) == f2
 @test norm(grad-gradfd)/norm(grad) < 1e-6
+
+# Testing precomposition by nonlinear operator
+
+b = randn(10)
+g = ProximalOperators.Translate(ProximalOperators.SqrNormL2(3.0), -b)
+G = AbstractOperators.Sigmoid((10,), 1.0)
+f = RegLS.PrecomposeNonlinear(g, G)
+
+x = randn(10)
+
+grad_f_x, f_x = gradient(f, x)
+
+@test size(grad_f_x) == size(x)
+@test abs(f_x - 3.0/2 * vecnorm(1.0 ./ (1.0 + exp.(-x)) - b)^2) <= 1e-10
+expx = exp.(x)
+expmx = 1.0./expx
+grad_f_x_ref = 3.0 * ( expx ./ (1 + expx).^2 ) .* (1.0 ./ (1.0 .+ expmx) - b)
+@test vecnorm(grad_f_x - grad_f_x_ref) <= 1e-10


### PR DESCRIPTION
This is (pretty much) how we should get smooth functions composed with general (smooth) operators working with the algorithms. This may go into ProximalOperators, but since it sort of "glues" together also AbstractOperators it might as well stay here.

Question: is the gradient inefficient?