### PR TITLE
Update requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.0'
+          version: '1.6'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
           - '1.4'
+          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ AbstractOperators = "0.1 - 0.2"
 DSP = "0.5.1 - 0.6"
 FFTW = "0.2.4 - 1.4"
 ProximalAlgorithms = "0.3 - 0.4"
-ProximalOperators = "0.8 - 0.14
+ProximalOperators = "0.8 - 0.14"
 RecursiveArrayTools = "0.18 - 2.11"
 julia = "1.4"
 

--- a/Project.toml
+++ b/Project.toml
@@ -14,10 +14,10 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 [compat]
 AbstractOperators = "0.1 - 0.2"
 DSP = "0.5.1 - 0.6"
-FFTW = "0.2.4 - 1.4"
+FFTW = "0.2.4 - 1"
 ProximalAlgorithms = "0.3 - 0.4"
 ProximalOperators = "0.8 - 0.14"
-RecursiveArrayTools = "0.18 - 2.11"
+RecursiveArrayTools = "0.18 - 2"
 julia = "1.4"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructuredOptimization"
 uuid = "46cd3e9d-64ff-517d-a929-236bc1a1fc9d"
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 AbstractOperators = "d9c5613a-d543-52d8-9afd-8f241a8c3f1c"
@@ -12,13 +12,13 @@ ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
 [compat]
-AbstractOperators = "≥ 0.1.0"
-DSP = "≥ 0.5.1"
-FFTW = "≥ 0.2.4"
-ProximalAlgorithms = "≥ 0.3.0"
-ProximalOperators = "≥ 0.8.0"
-RecursiveArrayTools = "≥ 0.18.0"
-julia = "1.0.0"
+AbstractOperators = "0.1 - 0.2"
+DSP = "0.5.1 - 0.6"
+FFTW = "0.2.4 - 1.4"
+ProximalAlgorithms = "0.3 - 0.4"
+ProximalOperators = "0.8 - 0.14
+RecursiveArrayTools = "0.18 - 2.11"
+julia = "1.4"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Addresses #33:
- Add upper bounds to requirements
- Bump Julia requirement to 1.4 because of hyphen version specifiers 
- Bump package version to 0.3.0
- Update test workflow to run on Julia 1.4 and 1.6